### PR TITLE
feat: `Query.whoami`をnullableに

### DIFF
--- a/schema.gql
+++ b/schema.gql
@@ -18,7 +18,7 @@ type Query {
   searchTags(input: SearchTagInput!): SearchTagsPayload!
 
   user(name: String!): User!
-  whoami: User!
+  whoami: User
 
   nicovideoVideoSource(sourceId: ID!): NicovideoVideoSource!
   findNicovideoVideoSource(sourceId: ID!): NicovideoVideoSource

--- a/src/resolvers/query/whoami.ts
+++ b/src/resolvers/query/whoami.ts
@@ -1,12 +1,9 @@
-import { GraphQLError } from "graphql";
-
 import { UserModel } from "../../graphql/models.js";
 import { QueryResolvers } from "../../graphql/resolvers.js";
 
 export const whoami =
   (): QueryResolvers["whoami"] =>
   async (_parent, _args, { user }) => {
-    if (!user) throw new GraphQLError("Invalid access token!");
-
+    if (!user) return null;
     return new UserModel(user);
   };


### PR DESCRIPTION
現状は未ログイン時には認証エラーを返すが，フロント側が割と頻繁に叩くクエリではあり，これをエラー処理を考慮しながら色々するのが煩雑すぎる