### PR TITLE
feat: PseudoTypeの算出方法を変える

### DIFF
--- a/prisma/migrations/20230312151513_category_typing/migration.sql
+++ b/prisma/migrations/20230312151513_category_typing/migration.sql
@@ -1,0 +1,26 @@
+-- CreateEnum
+CREATE TYPE "CategoryTagType" AS ENUM ('COPYRIGHT', 'CHARACTER', 'SERIES', 'MUSIC', 'TACTICS', 'EVENT', 'PHRASE', 'STYLE');
+
+-- CreateTable
+CREATE TABLE "CategoryTagTyping" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdById" TEXT NOT NULL,
+    "tagId" TEXT NOT NULL,
+    "type" "CategoryTagType" NOT NULL,
+
+    CONSTRAINT "CategoryTagTyping_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CategoryTagTyping_tagId_key" ON "CategoryTagTyping"("tagId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CategoryTagTyping_type_key" ON "CategoryTagTyping"("type");
+
+-- AddForeignKey
+ALTER TABLE "CategoryTagTyping" ADD CONSTRAINT "CategoryTagTyping_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CategoryTagTyping" ADD CONSTRAINT "CategoryTagTyping_tagId_fkey" FOREIGN KEY ("tagId") REFERENCES "Tag"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -200,9 +200,11 @@ model Tag {
   id     String @id @default(cuid())
   serial Int    @unique @default(autoincrement())
 
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @default(now())
-  meaningless Boolean
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now())
+
+  meaningless  Boolean
+  categoryType CategoryTagTyping?
 
   names TagName[]
 
@@ -214,6 +216,32 @@ model Tag {
   events TagEvent[]
 
   NicovideoSubmitRequestTagging NicovideoRegistrationRequestTagging[]
+}
+
+model CategoryTagTyping {
+  id String @id @default(cuid())
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now())
+
+  createdBy   User   @relation(fields: [createdById], references: [id])
+  createdById String
+
+  tag   Tag    @relation(fields: [tagId], references: [id])
+  tagId String @unique
+
+  type CategoryTagType @unique
+}
+
+enum CategoryTagType {
+  COPYRIGHT
+  CHARACTER
+  SERIES
+  MUSIC
+  TACTICS
+  EVENT
+  PHRASE
+  STYLE
 }
 
 model TagEvent {
@@ -362,6 +390,8 @@ model User {
   NicovideoRegistrationRequests         NicovideoRegistrationRequest[]
   NicovideoRegistrationRequestCheckings NicovideoRegistrationRequestChecking[]
   NicovideoRegistrationRequestEvents    NicovideoRegistrationRequestEvent[]
+
+  CategoryTagTyping CategoryTagTyping[]
 }
 
 enum UserRole {

--- a/src/resolvers/Mutation/index.ts
+++ b/src/resolvers/Mutation/index.ts
@@ -12,6 +12,7 @@ import { createMylistGroup } from "./createMylistGroup/createMylistGroup.js";
 import { resolverExplicitizeTagParent } from "./explicitizeTagParent/resolver.js";
 import { likeVideo } from "./likeVideo/likeVideo.js";
 import { registerCategoryTag } from "./registerCategoryTag/resolver.js";
+import { resolverRegisterCategoryTagTyping } from "./registerCategoryTagTyping/resolver.js";
 import { resolverRegisterTag } from "./registerTag/resolver.js";
 import { resolverRegisterTagParentRelation } from "./registerTagParentRelation/resolver.js";
 import { resolverRegisterVideo } from "./registerVideo/resolver.js";
@@ -38,6 +39,7 @@ export const resolveMutation = (deps: Pick<ResolverDeps, "prisma" | "neo4j" | "l
     explicitizeTagParent: resolverExplicitizeTagParent(deps),
     likeVideo: likeVideo(deps),
     registerCategoryTag: registerCategoryTag(deps),
+    registerCategoryTagTyping: resolverRegisterCategoryTagTyping(deps),
     registerTag: resolverRegisterTag(deps),
     registerTagParentRelation: resolverRegisterTagParentRelation(deps),
     registerVideo: resolverRegisterVideo(deps),

--- a/src/resolvers/Mutation/registerCategoryTagTyping/register.ts
+++ b/src/resolvers/Mutation/registerCategoryTagTyping/register.ts
@@ -1,0 +1,44 @@
+import { CategoryTagType, Tag } from "@prisma/client";
+
+import { err, ok, Result } from "../../../utils/Result.js";
+import { ResolverDeps } from "../../index.js";
+
+export const register = async (
+  prisma: ResolverDeps["prisma"],
+  {
+    userId,
+    tagId,
+    type,
+  }: {
+    userId: string;
+    tagId: string;
+    type: CategoryTagType;
+  }
+): Promise<
+  Result<
+    | { type: "UNKNOWN"; error: unknown }
+    | { type: "TYPE_ALREADY"; tag: Tag }
+    | { type: "TAG_NOT_FOUND"; id: string }
+    | { type: "TAG_NOT_CATEGORY_TAG"; tag: Tag }
+    | { type: "TAG_TYPE_ALREADY"; tag: Tag },
+    Tag
+  >
+> => {
+  try {
+    const already = await prisma.categoryTagTyping.findUnique({ where: { type }, select: { tag: true } });
+    if (already) return err({ type: "TYPE_ALREADY", tag: already.tag });
+
+    const category = await prisma.tag.findUnique({ where: { id: tagId }, include: { categoryType: true } });
+    if (!category) return err({ type: "TAG_NOT_FOUND", id: tagId });
+    if (!category.meaningless) return err({ type: "TAG_NOT_CATEGORY_TAG", tag: category });
+    if (category.categoryType) return err({ type: "TAG_TYPE_ALREADY", tag: category });
+
+    const typing = await prisma.categoryTagTyping.create({
+      data: { type, tagId: category.id, createdById: userId },
+      select: { tag: true },
+    });
+    return ok(typing.tag);
+  } catch (e) {
+    return err({ type: "UNKNOWN", error: e });
+  }
+};

--- a/src/resolvers/Mutation/registerCategoryTagTyping/registerCategoryTagTyping.graphql
+++ b/src/resolvers/Mutation/registerCategoryTagTyping/registerCategoryTagTyping.graphql
@@ -1,0 +1,51 @@
+type Mutation {
+  registerCategoryTagTyping(input: RegisterCategoryTagTypingInput!): RegisterCategoryTagTypingResultUnion!
+}
+
+input RegisterCategoryTagTypingInput {
+  tagId: ID!
+  type: TagType!
+}
+
+union RegisterCategoryTagTypingResultUnion =
+    MutationAuthenticationError
+  | MutationInvalidTagIdError
+  | MutationTagNotFoundError
+  | RegisterCategoryTagTypingUnsupportedTagType
+  | RegisterCategoryTagTypingAlreadyTypeExistsError
+  | RegisterCategoryTagTypingNotCategoryTagError
+  | RegisterCategoryTagTypingAlreadyTypedError
+  | RegisterCategoryTagTypingOtherErrorsFallback
+  | RegisterCategoryTagTypingSucceededPayload
+
+type RegisterCategoryTagTypingUnsupportedTagType {
+  type: TagType!
+}
+
+"指定されたタイプのカテゴリータグが既に存在する場合のエラー"
+type RegisterCategoryTagTypingAlreadyTypeExistsError {
+  already: Tag!
+}
+
+"指定されたタグはカテゴリータグでは無い場合のエラー"
+type RegisterCategoryTagTypingNotCategoryTagError {
+  tag: Tag!
+}
+
+"指定されたカテゴリータグに既にタイプがある場合のエラー"
+type RegisterCategoryTagTypingAlreadyTypedError {
+  tag: Tag!
+}
+
+"その他のエラー"
+type RegisterCategoryTagTypingOtherErrorsFallback {
+  message: RegisterCategoryTagTypingOtherErrorMessage!
+}
+
+enum RegisterCategoryTagTypingOtherErrorMessage {
+  INTERNAL_SERVER_ERROR
+}
+
+type RegisterCategoryTagTypingSucceededPayload {
+  tag: Tag!
+}

--- a/src/resolvers/Mutation/registerCategoryTagTyping/resolver.ts
+++ b/src/resolvers/Mutation/registerCategoryTagTyping/resolver.ts
@@ -1,0 +1,104 @@
+import { CategoryTagType, UserRole } from "@prisma/client";
+
+import { err, isErr, ok, Result } from "../../../utils/Result.js";
+import {
+  MutationResolvers,
+  RegisterCategoryTagTypingOtherErrorMessage,
+  ResolversTypes,
+  TagType as GqlTagType,
+  UserRole as GqlUserRole,
+} from "../../graphql.js";
+import { parseGqlID3 } from "../../id.js";
+import { ResolverDeps } from "../../index.js";
+import { TagModel } from "../../Tag/model.js";
+import { register } from "./register.js";
+
+const convertTagType = (g: GqlTagType): Result<GqlTagType, CategoryTagType> => {
+  switch (g) {
+    case GqlTagType.Music:
+      return ok(CategoryTagType.MUSIC);
+    case GqlTagType.Copyright:
+      return ok(CategoryTagType.COPYRIGHT);
+    case GqlTagType.Character:
+      return ok(CategoryTagType.CHARACTER);
+    case GqlTagType.Event:
+      return ok(CategoryTagType.EVENT);
+    case GqlTagType.Phrase:
+      return ok(CategoryTagType.PHRASE);
+    case GqlTagType.Series:
+      return ok(CategoryTagType.SERIES);
+    case GqlTagType.Style:
+      return ok(CategoryTagType.STYLE);
+    case GqlTagType.Tactics:
+      return ok(CategoryTagType.TACTICS);
+    default:
+      return err(g);
+  }
+};
+
+export const resolverRegisterCategoryTagTyping = ({ prisma, logger }: Pick<ResolverDeps, "prisma" | "logger">) =>
+  (async (_: unknown, { input }, { user }, info) => {
+    if (!user || user.role !== UserRole.ADMINISTRATOR)
+      return {
+        __typename: "MutationAuthenticationError",
+        requiredRole: GqlUserRole.Administrator,
+      } satisfies ResolversTypes["MutationAuthenticationError"];
+
+    const tagId = parseGqlID3("Tag", input.tagId);
+    if (isErr(tagId))
+      return {
+        __typename: "MutationInvalidTagIdError",
+        tagId: tagId.error.invalidId,
+      } satisfies ResolversTypes["MutationInvalidTagIdError"];
+
+    const tagtype = convertTagType(input.type);
+    if (isErr(tagtype))
+      return {
+        __typename: "RegisterCategoryTagTypingUnsupportedTagType",
+        type: tagtype.error,
+      } satisfies ResolversTypes["RegisterCategoryTagTypingUnsupportedTagType"];
+
+    const result = await register(prisma, {
+      userId: user.id,
+      tagId: tagId.data,
+      type: tagtype.data,
+    });
+
+    if (result.status === "error") {
+      switch (result.error.type) {
+        case "TYPE_ALREADY":
+          return {
+            __typename: "RegisterCategoryTagTypingAlreadyTypeExistsError",
+            already: new TagModel(result.error.tag),
+          } satisfies ResolversTypes["RegisterCategoryTagTypingAlreadyTypeExistsError"];
+        case "TAG_NOT_FOUND":
+          return {
+            __typename: "MutationTagNotFoundError",
+            tagId: result.error.id,
+          } satisfies ResolversTypes["MutationTagNotFoundError"];
+        case "TAG_NOT_CATEGORY_TAG":
+          return {
+            __typename: "RegisterCategoryTagTypingNotCategoryTagError",
+            tag: new TagModel(result.error.tag),
+          } satisfies ResolversTypes["RegisterCategoryTagTypingNotCategoryTagError"];
+        case "TAG_TYPE_ALREADY":
+          return {
+            __typename: "RegisterCategoryTagTypingAlreadyTypedError",
+            tag: new TagModel(result.error.tag),
+          } satisfies ResolversTypes["RegisterCategoryTagTypingAlreadyTypedError"];
+        case "UNKNOWN":
+          logger.error({ error: result.error, path: info.path }, "Resolver unknown error");
+          return {
+            __typename: "RegisterCategoryTagTypingOtherErrorsFallback",
+            message: RegisterCategoryTagTypingOtherErrorMessage.InternalServerError,
+          } satisfies ResolversTypes["RegisterCategoryTagTypingOtherErrorsFallback"];
+      }
+    }
+
+    const tag = result.data;
+
+    return {
+      __typename: "RegisterCategoryTagTypingSucceededPayload",
+      tag: new TagModel(tag),
+    } satisfies ResolversTypes["RegisterCategoryTagTypingSucceededPayload"];
+  }) satisfies MutationResolvers["registerCategoryTagTyping"];

--- a/src/resolvers/Tag/Tag.graphql
+++ b/src/resolvers/Tag/Tag.graphql
@@ -2,7 +2,7 @@ type Tag implements Node {
   id: ID!
   serial: Int!
 
-  pseudoType: PseudoTagType!
+  pseudoType: PseudoTagType! @deprecated
 
   name: String!
   names: [TagName!]!

--- a/src/resolvers/Tag/index.ts
+++ b/src/resolvers/Tag/index.ts
@@ -10,10 +10,12 @@ import { resolverChildren } from "./children/resolver.js";
 import { TagModel } from "./model.js";
 import { resolvePseudoType } from "./pseudoType.js";
 import { resolveTaggedVideos } from "./taggedVideos/resolver.js";
+import { resolveTagType } from "./type/resolver.js";
 
 export const resolveTag = ({ prisma, logger }: Pick<ResolverDeps, "prisma" | "logger">) =>
   ({
     id: ({ id }): string => buildGqlId("Tag", id),
+    type: resolveTagType({ prisma }),
     pseudoType: resolvePseudoType({ prisma }),
 
     names: async ({ id: tagId }) =>

--- a/src/resolvers/Tag/type/resolver.ts
+++ b/src/resolvers/Tag/type/resolver.ts
@@ -1,0 +1,39 @@
+import { CategoryTagType } from "@prisma/client";
+
+import { TagResolvers, TagType as GqlTagType } from "../../graphql.js";
+import { ResolverDeps } from "../../index.js";
+
+export const resolveTagType = ({ prisma }: Pick<ResolverDeps, "prisma">) =>
+  (async ({ id: tagId }) => {
+    const typings = await prisma.tagParent
+      .findMany({
+        where: { childId: tagId, parent: { meaningless: true } },
+        select: { parent: { select: { categoryType: { select: { type: true } } } } },
+      })
+      .then((t) =>
+        t.map(({ parent: { categoryType } }) => categoryType?.type).filter((t): t is CategoryTagType => !!t)
+      );
+
+    if (1 < typings.length) return GqlTagType.Subtle;
+    if (0 === typings.length) return GqlTagType.Unknown;
+    switch (typings[0]) {
+      case CategoryTagType.MUSIC:
+        return GqlTagType.Music;
+      case CategoryTagType.COPYRIGHT:
+        return GqlTagType.Copyright;
+      case CategoryTagType.CHARACTER:
+        return GqlTagType.Character;
+      case CategoryTagType.PHRASE:
+        return GqlTagType.Phrase;
+      case CategoryTagType.SERIES:
+        return GqlTagType.Series;
+      case CategoryTagType.TACTICS:
+        return GqlTagType.Tactics;
+      case CategoryTagType.STYLE:
+        return GqlTagType.Style;
+      case CategoryTagType.EVENT:
+        return GqlTagType.Event;
+      default:
+        return GqlTagType.Unknown;
+    }
+  }) satisfies TagResolvers["type"];

--- a/src/resolvers/Tag/type/type.graphql
+++ b/src/resolvers/Tag/type/type.graphql
@@ -1,0 +1,28 @@
+type Tag {
+  type: TagType!
+}
+
+enum TagType {
+  "曲"
+  MUSIC
+  "作品名"
+  COPYRIGHT
+  "キャラクター"
+  CHARACTER
+  "特徴的なセリフなど"
+  PHRASE
+  "シリーズ"
+  SERIES
+  "戦法"
+  TACTICS
+  "動画そのものに対しての性質，作風など"
+  STYLE
+  "動画の内容に依らない情報，分類など"
+  CLASS
+  "合作などのイベント"
+  EVENT
+  "2つ以上のタイプが算出された場合"
+  SUBTLE
+  "タイプを算出できなかった場合"
+  UNKNOWN
+}


### PR DESCRIPTION
Fixes #406

- `Tag.type`の追加
- `Tag.pseudoType`の廃止
- `Mutation.registerCategoryTagTyping`の追加